### PR TITLE
Implement PasswordConfig framework

### DIFF
--- a/password-manager-app/src/app/app.ts
+++ b/password-manager-app/src/app/app.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PasswordGeneratorService } from './password-generator.service';
-import { ConfigService, PasswordRecord } from './config.service';
+import { ConfigService, PasswordRecord, SecurityLevel } from './config.service';
 
 @Component({
   selector: 'app-root',
@@ -26,7 +26,7 @@ export class App {
       site: this.site,
       user: this.user,
       created: this.created,
-      level: 1
+      level: SecurityLevel.Low
     };
     this.config.addRecord(rec);
   }


### PR DESCRIPTION
## Summary
- add `SecurityLevel` enum and `SecurityLevelConfig` interface
- extend `PasswordRecord` and create `PasswordConfig`
- update ConfigService to use a single config object
- adjust App component to use new enum

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851bf70d3d4832e83376ef0f7090a6b