### PR TITLE
Implement security level selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# Development Guidelines
+
+This repository tracks the progress of a multi-phase password manager project. The
+`README.md` lists all phases and their status.
+
+* Keep `README.md` updated when a phase is completed.
+* Run `npm install` once before running tests if `node_modules` is missing.
+* Execute `npm test -- --watch=false` inside `password-manager-app` after code
+  changes. Tests may fail if Chrome is unavailable.
+
+## Current Progress
+* Phase 1 – Configurable database: **done**
+* Phase 2 – Security level selection in the UI: **done**
+* Phases 3+ – Not implemented yet

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ export enum SecurityLevel {
 
 #### **Fase 3 – Abstração de PRNG**
 
-* ✅ Criar uma interface `IPseudoRandomGenerator`:
+* ⬜ Criar uma interface `IPseudoRandomGenerator`:
 
 ```ts
 export interface IPseudoRandomGenerator {
@@ -48,7 +48,7 @@ export interface IPseudoRandomGenerator {
 }
 ```
 
-* ✅ Criar implementações como:
+* ⬜ Criar implementações como:
 
 | Nome           | Método                                                                  |
 | -------------- | ----------------------------------------------------------------------- |
@@ -56,13 +56,13 @@ export interface IPseudoRandomGenerator {
 | HMACPRNG       | HMAC-based Deterministic PRNG                                           |
 | WebCryptoPRNG  | Wrapper sobre crypto.subtle (não determinístico, para futuras features) |
 
-* ✅ Deixar o `PasswordGeneratorService` usar uma PRNG injetável
+* ⬜ Deixar o `PasswordGeneratorService` usar uma PRNG injetável
 
 ---
 
 #### **Fase 4 – Gerador de Senhas Hierárquico**
 
-* ✅ Para cada nível de segurança:
+* ⬜ Para cada nível de segurança:
 
 | Nível  | Método                                                                   |
 | ------ | ------------------------------------------------------------------------ |
@@ -75,7 +75,7 @@ export interface IPseudoRandomGenerator {
 
 #### **Fase 5 – Sistema de Dicas Mnemônicas**
 
-* ✅ Criar um tipo `MnemonicHint`:
+* ⬜ Criar um tipo `MnemonicHint`:
 
 ```ts
 export interface MnemonicHint {
@@ -86,26 +86,26 @@ export interface MnemonicHint {
 }
 ```
 
-* ✅ Criar UI:
+* ⬜ Criar UI:
 
   * Sugerir palavra
   * Usuário escreve o que a palavra lembra
   * Persistir isso no config
 
-* ✅ Adicionar a lista de dicas exportáveis junto no JSON
+* ⬜ Adicionar a lista de dicas exportáveis junto no JSON
 
 ---
 
 #### **Fase 6 – Export/Import Completo (Agora Incluindo Tudo)**
 
-* ✅ O método de exportação agora exporta o objeto completo `PasswordConfig`
-* ✅ Criptografia continua sendo AES-GCM com PBKDF2, mas agora sobre o novo JSON mais completo
+* ⬜ O método de exportação agora exporta o objeto completo `PasswordConfig`
+* ⬜ Criptografia continua sendo AES-GCM com PBKDF2, mas agora sobre o novo JSON mais completo
 
 ---
 
 #### **Fase 7 – Interface de Escolha de Algoritmo e Nível**
 
-* ✅ Dropdown ou radio buttons no formulário:
+* ⬜ Dropdown ou radio buttons no formulário:
 
   * Escolher nível de segurança
   * Escolher algoritmo de PRNG
@@ -114,7 +114,7 @@ export interface MnemonicHint {
 
 #### **Fase 8 – Testes e Validação de Determinismo**
 
-* ✅ Criar uma função de "replay generation":
+* ⬜ Criar uma função de "replay generation":
 
   * Dado um config + input, re-gerar todas as senhas anteriores e conferir se bate
 

--- a/password-manager-app/src/app/app.html
+++ b/password-manager-app/src/app/app.html
@@ -16,6 +16,12 @@
     Created
     <input type="date" name="created" [(ngModel)]="created" />
   </label>
+  <label>
+    Level
+    <select name="level" [(ngModel)]="level">
+      <option *ngFor="let lvl of levels" [ngValue]="lvl.value">{{lvl.label}}</option>
+    </select>
+  </label>
   <button type="submit" [disabled]="!f.form.valid">Generate</button>
 </form>
 <p *ngIf="password">Generated: <code>{{password}}</code></p>

--- a/password-manager-app/src/app/app.ts
+++ b/password-manager-app/src/app/app.ts
@@ -16,6 +16,14 @@ export class App {
   master = '';
   created = new Date().toISOString().substring(0,10);
   password = '';
+  level: SecurityLevel = SecurityLevel.Low;
+
+  levels = [
+    { value: SecurityLevel.Low, label: 'Low - Básico' },
+    { value: SecurityLevel.Medium, label: 'Medium - Recomendado' },
+    { value: SecurityLevel.High, label: 'High - Sensível' },
+    { value: SecurityLevel.Ultra, label: 'Ultra - Máxima Segurança' }
+  ];
 
   constructor(private gen: PasswordGeneratorService, private config: ConfigService) {}
 
@@ -26,7 +34,7 @@ export class App {
       site: this.site,
       user: this.user,
       created: this.created,
-      level: SecurityLevel.Low
+      level: this.level
     };
     this.config.addRecord(rec);
   }

--- a/password-manager-app/src/app/config.service.ts
+++ b/password-manager-app/src/app/config.service.ts
@@ -78,7 +78,13 @@ export class ConfigService {
     const pwKey = await this.deriveKey(password);
     const plain = await crypto.subtle.decrypt({ name: 'AES-GCM', iv }, pwKey, data);
     const dec = new TextDecoder().decode(plain);
-    this.config = JSON.parse(dec) as PasswordConfig;
+    const parsed = JSON.parse(dec) as PasswordConfig;
+    for (const rec of parsed.records) {
+      if (rec.level === undefined) {
+        (rec as PasswordRecord).level = SecurityLevel.Low;
+      }
+    }
+    this.config = parsed;
   }
 
   private async deriveKey(password: string) {


### PR DESCRIPTION
## Summary
- add dropdown to select password security level
- include the selected level in the added record
- ensure imported configs default missing levels to Low
- document progress and add development guidelines

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser)*

------
https://chatgpt.com/codex/tasks/task_e_6851c305fe90832e9a282544e4a3094e